### PR TITLE
Avoid overlap of the scrollbar with the content of the last line

### DIFF
--- a/src/components/LazyLog/LazyList.js
+++ b/src/components/LazyLog/LazyList.js
@@ -162,6 +162,11 @@ export class LazyList extends React.PureComponent {
 
   renderRow({ key, index, style }) {
     const number = index + 1 + this.state.offset;
+    
+    // Avoid horizontal scrollbar overlap with the last line of the log
+    if (index === this.state.count - 1) {
+      style.height *= 3;
+    }
 
     return (
       <Line


### PR DESCRIPTION
Scrollbars act differently depending on your machine. On macOS for example, the scrollbar fades away when you stop scrolling, allowing you to see the content underneath it. But for someone running a Window machine, for example, the scrollbar stays visible and so the content beneath it becomes hidden.

Presently, the horizontal scrollbar at the end of a log is overlapping with the content of its last line. This pull-request solves the issue by increasing the height of the last line of the viewer.

Some complaints:
* https://bugzilla.mozilla.org/show_bug.cgi?id=1380540
* https://bugzilla.mozilla.org/show_bug.cgi?id=1381009