### PR TITLE
Emit error event if request fails in stream()

### DIFF
--- a/src/components/LazyLog/stream.js
+++ b/src/components/LazyLog/stream.js
@@ -49,6 +49,15 @@ export const stream = (url, options) => {
     try {
       const fetch = await fetcher;
       const response = await fetch(url, Object.assign({ credentials: 'omit' }, options));
+
+      if (!response.ok) {
+        const error = new Error(response.statusText);
+
+        error.status = response.status;
+        emitter.emit('error', error);
+        return;
+      }
+
       const reader = response.body.getReader();
 
       emitter.on('abort', () => reader.cancel('ABORTED'));


### PR DESCRIPTION
I have realized that the `onError` callback was not working for `LazyStream`.

I have seen in `request.js` there is some code that emits the error event is the response is not ok. That wasn't the case of `stream.js`.