### PR TITLE
Add `selectableLines` prop for allowing selecting and copying text lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ quicker upfront rendering as content can be decoded as it arrives.
 | `highlight` | Number or Array |  | Line number (e.g. `highlight={10}`) or line number range to highlight inclusively (e.g. `highlight={[5, 10]}` highlights lines 5-10). This is 1-indexed, i.e. line numbers start at `1`. |
 | `scrollToLine` | Number |  | Scroll to a particular line number once it has loaded. This is 1-indexed, i.e. line numbers start at `1`. Cannot be used in combination with `follow`. |
 | `follow` | Boolean |  | Scroll to the end of the component after each update to the content. Cannot be used in combination with `scrollToLine`. |
+| `selectableLines` | Boolean |  | Make the text selectable, allowing to copy & paste. Defaults to `false`. |
 | `formatPart` | Function |  | Execute a function against each string part of a line, returning a new line part. Is passed a single argument which is the string part to manipulate, should return a new string with the manipulation completed. |
 | `onLoad` | Function |  | Execute a function if/when the provided `url` has completed loading. |
 | `onError` | Function |  | Execute a function if the provided `url` has encountered an error during loading. |

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -13,11 +13,9 @@ module.exports = {
     {
       name: 'LAZYLOG_CLIENT',
       script: 'node_modules/.bin/neutrino',
+      args: '--options.port=9001',
       args: 'start',
       watch: false,
-      env: {
-        PORT: 9001
-      }
     }
   ]
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-lazylog",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "description": "React Lazy Logviewer",
   "license": "MPL-2.0",
   "repository": "mozilla-rpweb/react-lazylog",

--- a/src/components/LazyLog/LazyList.js
+++ b/src/components/LazyLog/LazyList.js
@@ -161,6 +161,7 @@ export class LazyList extends React.PureComponent {
         key={key}
         number={number}
         formatPart={this.props.formatPart}
+        selectable={this.props.selectableLines}
         highlight={this.state.highlight.includes(number)}
         onLineNumberClick={this.handleHighlight.bind(this, number)}>
         {ansiparse(decode(this.state.lines.get(index)))}
@@ -206,6 +207,7 @@ LazyList.defaultProps = {
   follow: false,
   scrollToLine: 0,
   highlight: null,
+  selectableLines: false,
   rowHeight: 19,
   overscanRowCount: 100,
   containerStyle: {

--- a/src/components/LazyLog/Line.js
+++ b/src/components/LazyLog/Line.js
@@ -1,12 +1,13 @@
 import React from 'react';
 import { LineNumber } from './LineNumber';
 import { LineContent } from './LineContent';
-import { line, lineHighlight, lineHover } from './styles.css';
+import { line, lineHighlight, lineHover, lineSelectable } from './styles.css';
 
 export const Line = ({
   children,
   formatPart,
   highlight = false,
+  selectable = false,
   onLineNumberClick,
   onRowClick,
   number,
@@ -14,7 +15,9 @@ export const Line = ({
   style
 }) => {
   const handleHover = ({ currentTarget, type }) => currentTarget.classList.toggle(lineHover, type === 'mouseenter');
-  const className = highlight ? `${line} ${lineHighlight}` : line;
+  const highlightClass = highlight ? ` ${lineHighlight}` : '';
+  const selectableClass = selectable ? ` ${lineSelectable}` : '';
+  const className = `${line}${highlightClass}${selectableClass}`;
   const lineStyle = {
     ...style,
     lineHeight: `${style ? style.height || rowHeight : rowHeight}px`,

--- a/src/components/LazyLog/styles.css
+++ b/src/components/LazyLog/styles.css
@@ -15,6 +15,10 @@
   user-select: none;
 }
 
+.lineSelectable {
+  user-select: text;
+}
+
 .lineHighlight {
   background-color: #666666;
 }

--- a/src/stories.js
+++ b/src/stories.js
@@ -24,16 +24,18 @@ const load = () => render((
         <Props name="Typical, follow" url={logs.TYPICAL} follow={true} />
         <Props name="Typical, highlight L10" url={logs.TYPICAL} highlight={10} />
         <Props name="Typical, highlight L5-L15" url={logs.TYPICAL} highlight={[5, 15]} />
+        <Props name="Typical Log, selectable lines" url={logs.TYPICAL} selectableLines={true} />
         <Props name="Massive Log, scroll to 500K" url={logs.MASSIVE} scrollToLine={500000} />
         <Props name="403 Error, Fixed dimensions" url={logs.HTTP_403} height={100} width={550} />
         <Props name="404 Error" url={logs.HTTP_404} />
         <Props name="Missing CORS headers" url={logs.MISSING_CORS} />
-        <Props name="Generic error" url={logs.BAD_URL} />
+        <Props name="Generic error" url={logs.BAD_URL} selectableLines={true} />
       </Story>
       <Story component={LazyStream}>
         <Props name="Local Stream" url={logs.LOCAL_STREAM} />
         <Props name="Local Stream, scroll To 30" url={logs.LOCAL_STREAM} scrollToLine={30} />
         <Props name="Local Stream, follow" url={logs.LOCAL_STREAM} follow={true} />
+        <Props name="Local Stream, selectable lines" url={logs.LOCAL_STREAM} selectableLines={true} />
       </Story>
       <Story component={ScrollFollow}>
         <Props name="Not following">


### PR DESCRIPTION
I find a bit annoying not being able to copy & paste text from the log viewer, but I'm not aware of the circumstances why it was disabled by default. For that reason, I've added an option to make it configurable.

I wasn't sure if I should also add the version bump so please let me know if I should revert it!

Note: while adding a case for this prop to the "stories", I've noticed that the port for the dev. server was not being taken by `neutrino`, hence the change in `ecosystem.config.js`. Also, the "typical" and "massive" URLs for log examples doesn't seem to work.